### PR TITLE
Create Office365User.md

### DIFF
--- a/Documentation/Classes/Office365User.md
+++ b/Documentation/Classes/Office365User.md
@@ -1,0 +1,19 @@
+<!-- Type your summary here -->
+# Office365User
+
+User service for Office365.
+
+## Get an instance
+
+Get it from `user` attribute of `Office365` instance.
+
+```4d
+var $user : cs.NetKit.Office365User
+$user:=$office365.user // with $office365 an instance of cs.NetKit.Office365
+```
+
+## Functions
+
+- [get](https://github.com/4d/4D-NetKit#office365userget)
+- [getCurrent](https://github.com/4d/4D-NetKit#office365usergetcurrent)
+- [list](https://github.com/4d/4D-NetKit#office365userlist)


### PR DESCRIPTION
Follow this request https://discuss.4d.com/t/include-documentation-for-native-4d-components/22864
but for classes

I use `Office365User` as example.

And here a screenshot to see in action 
![Screenshot 2023-02-02 at 14 58 55](https://user-images.githubusercontent.com/59135882/216346335-94fcf714-8586-41a1-adda-87453fc1a651.png)

---

Unfortunately when clicking on function there is no associated doc or link 
(here touching `get` function in explorer tree could open classes/Office365User.md with #get fragment and we could adapt the doc for that..  , a 4D dev must done for that)

link for function point the doc

- [get](https://github.com/4d/4D-NetKit#office365userget)
- [getCurrent](https://github.com/4d/4D-NetKit#office365usergetcurrent)
- [list](https://github.com/4d/4D-NetKit#office365userlist)