### PR TITLE
Fix Office365 Graph mail property validation

### DIFF
--- a/Documentation/Assets/UML Diagram.svg
+++ b/Documentation/Assets/UML Diagram.svg
@@ -37,18 +37,18 @@ text { font-family: 'Segoe UI', Arial, sans-serif; }
 <path class='edge' d='M 4090 2080 L 4090 2129 L 3610 2267 L 3610 2316'/>
 <path class='edge' d='M 1210 2436 L 1210 2485 L 3370 2931 L 3370 2980'/>
 <path class='edge' d='M 1210 2436 L 1210 2485 L 3850 2931 L 3850 2980'/>
-<path class='edge' d='M 4090 2080 L 4090 2129 L 4090 2267 L 4090 2316'/>
+<path class='edge' d='M 4090 2112 L 4090 2161 L 4090 2267 L 4090 2316'/>
 <path class='edge' d='M 1210 2436 L 1210 2485 L 4330 2931 L 4330 2980'/>
 <path class='edge' d='M 1210 2436 L 1210 2485 L 4810 2931 L 4810 2980'/>
-<path class='edge' d='M 4090 2080 L 4090 2129 L 4570 2267 L 4570 2316'/>
+<path class='edge' d='M 4090 2112 L 4090 2161 L 4570 2267 L 4570 2316'/>
 <path class='edge' d='M 1210 2436 L 1210 2485 L 5290 2931 L 5290 2980'/>
-<path class='edge' d='M 4090 2080 L 4090 2129 L 5050 2267 L 5050 2316'/>
+<path class='edge' d='M 4090 2112 L 4090 2161 L 5050 2267 L 5050 2316'/>
 <path class='edge' d='M 1210 2436 L 1210 2485 L 5770 2931 L 5770 2980'/>
 <path class='edge' d='M 250 368 L 250 417 L 4090 795 L 4090 844'/>
-<path class='edge' d='M 4090 2080 L 4090 2129 L 5530 2267 L 5530 2316'/>
-<path class='edge' d='M 4090 2080 L 4090 2129 L 6010 2267 L 6010 2316'/>
-<path class='edge' d='M 4090 2080 L 4090 2129 L 6490 2267 L 6490 2316'/>
-<path class='edge' d='M 4090 2080 L 4090 2129 L 6970 2267 L 6970 2316'/>
+<path class='edge' d='M 4090 2112 L 4090 2161 L 5530 2267 L 5530 2316'/>
+<path class='edge' d='M 4090 2112 L 4090 2161 L 6010 2267 L 6010 2316'/>
+<path class='edge' d='M 4090 2112 L 4090 2161 L 6490 2267 L 6490 2316'/>
+<path class='edge' d='M 4090 2112 L 4090 2161 L 6970 2267 L 6970 2316'/>
 <rect x='2920' y='844' width='420' height='188' rx='10' ry='10' fill='#fee2e2' stroke='#dc2626' stroke-width='1.2'/>
 <line x1='2920' y1='880' x2='3340' y2='880' stroke='#dc2626' stroke-opacity='0.5'/>
 <text class='cn' x='2932' y='868'>_BaseAPI</text>
@@ -160,13 +160,15 @@ text { font-family: 'Segoe UI', Arial, sans-serif; }
 <text class='m' x='532' y='2540'>+appendRequest($inParam : Object)</text>
 <text class='m' x='532' y='2556'>+constructor($inProvider : cs.OAuth2Provider; $inParam : Object)</text>
 <text class='m' x='532' y='2572'>+sendRequestAndWaitResponse() : Collection</text>
-<rect x='3880' y='1940' width='420' height='140' rx='10' ry='10' fill='#fee2e2' stroke='#dc2626' stroke-width='1.2'/>
+<rect x='3880' y='1940' width='420' height='172' rx='10' ry='10' fill='#fee2e2' stroke='#dc2626' stroke-width='1.2'/>
 <line x1='3880' y1='1976' x2='4300' y2='1976' stroke='#dc2626' stroke-opacity='0.5'/>
 <text class='cn' x='3892' y='1964'>_GraphAPI</text>
 <text class='m' x='3892' y='1994'>-_copyGraphMessage($inMessage : Object) : Object</text>
 <text class='m' x='3892' y='2010'>-_getURLParamsFromObject($inParameters : Object; $inCount : Boolean) : Text</text>
 <text class='m' x='3892' y='2026'>-_loadFromObject($inObject : Object)</text>
-<text class='m' x='3892' y='2042'>+constructor($inProvider : cs.OAuth2Provider)</text>
+<text class='m' x='3892' y='2042'>-_validateGraphMessageProperties($inPayload : Object; $inFunction : Text) : Boolean</text>
+<text class='m' x='3892' y='2058'>-_validateJMAPMessageProperties($inMail : Object; $inFunction : Text) : Boolean</text>
+<text class='m' x='3892' y='2074'>+constructor($inProvider : cs.OAuth2Provider)</text>
 <rect x='1000' y='2316' width='420' height='120' rx='10' ry='10' fill='#fee2e2' stroke='#dc2626' stroke-width='1.2'/>
 <line x1='1000' y1='2352' x2='1420' y2='2352' stroke='#dc2626' stroke-opacity='0.5'/>
 <text class='cn' x='1012' y='2340'>_GraphBaseList</text>
@@ -631,7 +633,7 @@ text { font-family: 'Segoe UI', Arial, sans-serif; }
 <text class='m' x='6292' y='2370'>+mailType : Text</text>
 <text class='m' x='6292' y='2386'>+userId : Text</text>
 <line x1='6290' y1='2397' x2='6690' y2='2397' stroke='#16a34a' stroke-opacity='0.35'/>
-<text class='m' x='6292' y='2412'>-_postJSONMessage($inURL : Text; $inMail : Object; $bSkipMessageEncapsulation : Boolean; $inHeaders : Object) : Object</text>
+<text class='m' x='6292' y='2412'>-_postJSONMessage($inFunction : Text; $inURL : Text; $inMail : Object; $bSkipMessageEncapsulation : Boolean; $inHeaders : Object) : Object</text>
 <text class='m' x='6292' y='2428'>-_postMailMIMEMessage($inURL : Text; $inMail : Variant) : Object</text>
 <text class='m' x='6292' y='2444'>-_postMessage($inFunction : Text; $inURL : Text; $inMail : Variant; $bSkipMessageEncapsulation : Boolean; $inHeader : Object) : Object</text>
 <text class='m' x='6292' y='2460'>+append($inMail : Variant; $inFolderId : Text) : Object</text>

--- a/Documentation/Classes/Office365.md
+++ b/Documentation/Classes/Office365.md
@@ -596,49 +596,6 @@ The `event` object used with Microsoft Calendar methods includes the following m
 
 ## Mail 
 
-### Mail validation architecture
-
-When sending or appending a mail message, `Office365Mail` routes the payload through format-specific validation before the HTTP call is made. The diagram below shows the class relationships and the validation flow.
-
-```mermaid
-classDiagram
-    class _GraphAPI {
-        +_validateGraphMessageProperties(payload, function) Boolean
-        +_validateJMAPMessageProperties(mail, function) Boolean
-        +_copyGraphMessage(message) Object
-        +_loadFromObject(object)
-        +_getURLParamsFromObject(parameters, count) Text
-    }
-
-    class Office365Mail {
-        +mailType : Text
-        +userId : Text
-        +send(mail, options) Object
-        +append(mail, folderId) Object
-        +update(mailId, mail) Object
-        +reply(mailId, mail, options) Object
-        -_postMessage(function, url, mail, skipEncap, headers) Object
-        -_postJSONMessage(function, url, mail, skipEncap, headers) Object
-        -_postMailMIMEMessage(url, mail) Object
-    }
-
-    _GraphAPI <|-- Office365Mail
-
-    note for Office365Mail "_postMessage dispatch:\n• mailType=Microsoft → _validateGraphMessageProperties → _postJSONMessage\n• mailType=JMAP     → _validateJMAPMessageProperties → _postMailMIMEMessage\n• mailType=MIME     → _postMailMIMEMessage (no validation)"
-```
-
-#### Supported Microsoft Graph message properties
-
-The `_validateGraphMessageProperties` method accepts these Microsoft Graph [message resource](https://learn.microsoft.com/en-us/graph/api/resources/message?view=graph-rest-1.0) keys:
-
-`attachments`, `bccRecipients`, `body`, `bodyPreview`, `categories`, `ccRecipients`, `changeKey`, `conversationId`, `conversationIndex`, `createdDateTime`, `extensions`, `flag`, `from`, `hasAttachments`, `id`, `importance`, `inferenceClassification`, `internetMessageHeaders`, `internetMessageId`, `isDeliveryReceiptRequested`, `isDraft`, `isRead`, `isReadReceiptRequested`, `lastModifiedDateTime`, `multiValueExtendedProperties`, `parentFolderId`, `receivedDateTime`, `replyTo`, `sender`, `sentDateTime`, `singleValueExtendedProperties`, `subject`, `toRecipients`, `uniqueBody`, `webLink`
-
-#### Supported JMAP message properties
-
-The `_validateJMAPMessageProperties` method accepts these 4D email object (RFC 8621) keys:
-
-`from`, `to`, `cc`, `bcc`, `replyTo`, `sender`, `subject`, `sentAt`, `receivedAt`, `textBody`, `htmlBody`, `bodyValues`, `attachments`, `keywords`, `headers`, `messageId`, `inReplyTo`, `references`, `id`, `threadId`, `preview`, `size`, `hasAttachment`, `mailboxIds`
-
 ### Office365.mail.append()
 
 **Office365.mail.append**( *email* : Object ; *folderId* : Text) : Object

--- a/Documentation/Classes/Office365.md
+++ b/Documentation/Classes/Office365.md
@@ -595,7 +595,50 @@ The `event` object used with Microsoft Calendar methods includes the following m
 | hideAttendees  | | Boolean    | (Default: false) If `true`, attendees will only see themselves.|Yes|                                                             
 
 ## Mail 
- 
+
+### Mail validation architecture
+
+When sending or appending a mail message, `Office365Mail` routes the payload through format-specific validation before the HTTP call is made. The diagram below shows the class relationships and the validation flow.
+
+```mermaid
+classDiagram
+    class _GraphAPI {
+        +_validateGraphMessageProperties(payload, function) Boolean
+        +_validateJMAPMessageProperties(mail, function) Boolean
+        +_copyGraphMessage(message) Object
+        +_loadFromObject(object)
+        +_getURLParamsFromObject(parameters, count) Text
+    }
+
+    class Office365Mail {
+        +mailType : Text
+        +userId : Text
+        +send(mail, options) Object
+        +append(mail, folderId) Object
+        +update(mailId, mail) Object
+        +reply(mailId, mail, options) Object
+        -_postMessage(function, url, mail, skipEncap, headers) Object
+        -_postJSONMessage(function, url, mail, skipEncap, headers) Object
+        -_postMailMIMEMessage(url, mail) Object
+    }
+
+    _GraphAPI <|-- Office365Mail
+
+    note for Office365Mail "_postMessage dispatch:\n• mailType=Microsoft → _validateGraphMessageProperties → _postJSONMessage\n• mailType=JMAP     → _validateJMAPMessageProperties → _postMailMIMEMessage\n• mailType=MIME     → _postMailMIMEMessage (no validation)"
+```
+
+#### Supported Microsoft Graph message properties
+
+The `_validateGraphMessageProperties` method accepts these Microsoft Graph [message resource](https://learn.microsoft.com/en-us/graph/api/resources/message?view=graph-rest-1.0) keys:
+
+`attachments`, `bccRecipients`, `body`, `bodyPreview`, `categories`, `ccRecipients`, `changeKey`, `conversationId`, `conversationIndex`, `createdDateTime`, `extensions`, `flag`, `from`, `hasAttachments`, `id`, `importance`, `inferenceClassification`, `internetMessageHeaders`, `internetMessageId`, `isDeliveryReceiptRequested`, `isDraft`, `isRead`, `isReadReceiptRequested`, `lastModifiedDateTime`, `multiValueExtendedProperties`, `parentFolderId`, `receivedDateTime`, `replyTo`, `sender`, `sentDateTime`, `singleValueExtendedProperties`, `subject`, `toRecipients`, `uniqueBody`, `webLink`
+
+#### Supported JMAP message properties
+
+The `_validateJMAPMessageProperties` method accepts these 4D email object (RFC 8621) keys:
+
+`from`, `to`, `cc`, `bcc`, `replyTo`, `sender`, `subject`, `sentAt`, `receivedAt`, `textBody`, `htmlBody`, `bodyValues`, `attachments`, `keywords`, `headers`, `messageId`, `inReplyTo`, `references`, `id`, `threadId`, `preview`, `size`, `hasAttachment`, `mailboxIds`
+
 ### Office365.mail.append()
 
 **Office365.mail.append**( *email* : Object ; *folderId* : Text) : Object

--- a/Project/Sources/Classes/Office365Mail.4dm
+++ b/Project/Sources/Classes/Office365Mail.4dm
@@ -31,10 +31,11 @@ Class constructor($inProvider : cs.OAuth2Provider; $inParameters : Object)
 	// ----------------------------------------------------
 	
 	
-Function _postJSONMessage($inURL : Text; $inMail : Object; $bSkipMessageEncapsulation : Boolean; $inHeaders : Object) : Object
+Function _postJSONMessage($inFunction : Text; $inURL : Text; $inMail : Object; $bSkipMessageEncapsulation : Boolean; $inHeaders : Object) : Object
 /**
  * @function _postJSONMessage
  * @private
+ * @param {Text} $inFunction - Caller name for error reporting (e.g. `"office365.mail.send"`)
  * @param {Text} $inURL - Target Graph API endpoint URL
  * @param {Object} $inMail - Mail object in Microsoft Graph JSON format
  * @param {Boolean} $bSkipMessageEncapsulation - When `True`, sends `$inMail` as-is;
@@ -53,6 +54,10 @@ Function _postJSONMessage($inURL : Text; $inMail : Object; $bSkipMessageEncapsul
 			$headers:=OB Copy($inHeaders)
 		End if 
 		$headers["Content-Type"]:="application/json"
+		
+		If (Not(This._validateGraphMessageProperties($inMail; $inFunction)))
+			return This._returnStatus()
+		End if 
 		
 		var $message : Object
 		var $messageCopy : Object:=This._copyGraphMessage($inMail)
@@ -149,7 +154,7 @@ Function _postMessage($inFunction : Text; $inURL : Text; $inMail : Variant; $bSk
 				$status:=This._postMailMIMEMessage($inURL; $inMail)
 				
 			: ((This.mailType="Microsoft") && (Value type($inMail)=Is object))
-				$status:=This._postJSONMessage($inURL; $inMail; $bSkipMessageEncapsulation; $inHeader)
+				$status:=This._postJSONMessage($inFunction; $inURL; $inMail; $bSkipMessageEncapsulation; $inHeader)
 				
 			Else 
 				Super._throwError(10; {which: 1; function: $inFunction})
@@ -541,6 +546,10 @@ Function update($inMailId : Text; $inMail : Object) : Object
 	Try
 		
 		If ((Type($inMail)=Is object) && (Type($inMailId)=Is text) && (Length(String($inMailId))>0))
+			
+			If (Not(This._validateGraphMessageProperties($inMail; "office365.mail.update")))
+				return This._returnStatus()
+			End if 
 			
 			var $response : Object
 			var $URL : Text:=Super._getURL()

--- a/Project/Sources/Classes/Office365Mail.4dm
+++ b/Project/Sources/Classes/Office365Mail.4dm
@@ -133,7 +133,9 @@ Function _postMessage($inFunction : Text; $inURL : Text; $inMail : Variant; $bSk
  * @param {Object} $inHeader - Additional HTTP headers forwarded to `_postJSONMessage`
  * @returns {Object} Status object
  * @description Dispatches to `_postJSONMessage` or `_postMailMIMEMessage` based on `mailType`
- *   and the actual type of `$inMail`; throws error 10 on type mismatch
+ *   and the actual type of `$inMail`; throws error 10 on type mismatch.
+ *   JMAP objects are validated via `_validateJMAPMessageProperties` before conversion;
+ *   Microsoft Graph objects are validated via `_validateGraphMessageProperties`.
  */
 	
 	var $status : Object
@@ -151,7 +153,11 @@ Function _postMessage($inFunction : Text; $inURL : Text; $inMail : Variant; $bSk
 				$status:=This._postMailMIMEMessage($inURL; $inMail)
 				
 			: ((This.mailType="JMAP") && (Value type($inMail)=Is object))
-				$status:=This._postMailMIMEMessage($inURL; $inMail)
+				If (This._validateJMAPMessageProperties($inMail; $inFunction))
+					$status:=This._postMailMIMEMessage($inURL; $inMail)
+				Else 
+					$status:=This._returnStatus()
+				End if 
 				
 			: ((This.mailType="Microsoft") && (Value type($inMail)=Is object))
 				$status:=This._postJSONMessage($inFunction; $inURL; $inMail; $bSkipMessageEncapsulation; $inHeader)

--- a/Project/Sources/Classes/_GraphAPI.4dm
+++ b/Project/Sources/Classes/_GraphAPI.4dm
@@ -76,6 +76,94 @@ Function _copyGraphMessage($inMessage : Object) : Object
 	// ----------------------------------------------------
 	
 	
+Function _validateGraphMessageProperties($inPayload : Object; $inFunction : Text) : Boolean
+/**
+ * @function _validateGraphMessageProperties
+ * @private
+ * @param {Object} $inPayload - Graph message object or request envelope (`{message: ...}`)
+ * @param {Text} $inFunction - Caller function name for error reporting
+ * @returns {Boolean} `True` when all properties are supported; otherwise `False`
+ * @description Validates mail payload keys before sending to Microsoft Graph.
+ *   Adds an error to the stack for each unsupported property (for example `attachment`
+ *   instead of `attachments`).
+ */
+	
+	var $isValid : Boolean:=True
+	
+	If (($inPayload#Null) && (Value type($inPayload)=Is object))
+		
+		var $message : Object
+		var $allowedPayloadKeys : Object:={message: True; saveToSentItems: True; comment: True}
+		If (OB Is defined($inPayload; "message") && (Value type($inPayload.message)=Is object))
+			$message:=$inPayload.message
+			
+			var $payloadKey : Text
+			For each ($payloadKey; OB Keys($inPayload))
+				If (Not(OB Is defined($allowedPayloadKeys; $payloadKey)))
+					This._pushError(12; {function: $inFunction; message: "Unsupported property \""+$payloadKey+"\" in mail payload."})
+					$isValid:=False
+				End if 
+			End for each 
+		Else 
+			$message:=$inPayload
+		End if 
+		
+		var $messageKey : Text
+		For each ($messageKey; OB Keys($message))
+			var $isAllowed : Boolean:=False
+			Case of 
+				: ($messageKey="attachments")
+				: ($messageKey="bccRecipients")
+				: ($messageKey="body")
+				: ($messageKey="bodyPreview")
+				: ($messageKey="categories")
+				: ($messageKey="ccRecipients")
+				: ($messageKey="changeKey")
+				: ($messageKey="conversationId")
+				: ($messageKey="conversationIndex")
+				: ($messageKey="createdDateTime")
+				: ($messageKey="extensions")
+				: ($messageKey="flag")
+				: ($messageKey="from")
+				: ($messageKey="hasAttachments")
+				: ($messageKey="id")
+				: ($messageKey="importance")
+				: ($messageKey="inferenceClassification")
+				: ($messageKey="internetMessageHeaders")
+				: ($messageKey="internetMessageId")
+				: ($messageKey="isDeliveryReceiptRequested")
+				: ($messageKey="isDraft")
+				: ($messageKey="isRead")
+				: ($messageKey="isReadReceiptRequested")
+				: ($messageKey="lastModifiedDateTime")
+				: ($messageKey="multiValueExtendedProperties")
+				: ($messageKey="parentFolderId")
+				: ($messageKey="receivedDateTime")
+				: ($messageKey="replyTo")
+				: ($messageKey="sender")
+				: ($messageKey="sentDateTime")
+				: ($messageKey="singleValueExtendedProperties")
+				: ($messageKey="subject")
+				: ($messageKey="toRecipients")
+				: ($messageKey="uniqueBody")
+				: ($messageKey="webLink")
+					$isAllowed:=True
+			End case 
+			
+			If (Not($isAllowed))
+				This._pushError(12; {function: $inFunction; message: "Unsupported property \""+$messageKey+"\" in mail object."})
+				$isValid:=False
+			End if 
+		End for each 
+		
+	End if 
+	
+	return $isValid
+	
+	
+	// ----------------------------------------------------
+	
+	
 Function _loadFromObject($inObject : Object)
 /**
  * @function _loadFromObject

--- a/Project/Sources/Classes/_GraphAPI.4dm
+++ b/Project/Sources/Classes/_GraphAPI.4dm
@@ -85,7 +85,8 @@ Function _validateGraphMessageProperties($inPayload : Object; $inFunction : Text
  * @returns {Boolean} `True` when all properties are supported; otherwise `False`
  * @description Validates mail payload keys before sending to Microsoft Graph.
  *   Adds an error to the stack for each unsupported property (for example `attachment`
- *   instead of `attachments`).
+ *   instead of `attachments`). Uses a Collection-based lookup for O(1)-style
+ *   maintainability and readability over a `Case of` chain.
  */
 	
 	var $isValid : Boolean:=True
@@ -108,50 +109,62 @@ Function _validateGraphMessageProperties($inPayload : Object; $inFunction : Text
 			$message:=$inPayload
 		End if 
 		
+		var $allowedMessageKeys : Collection:=New collection(\
+			"attachments"; "bccRecipients"; "body"; "bodyPreview"; \
+			"categories"; "ccRecipients"; "changeKey"; "conversationId"; \
+			"conversationIndex"; "createdDateTime"; "extensions"; "flag"; \
+			"from"; "hasAttachments"; "id"; "importance"; "inferenceClassification"; \
+			"internetMessageHeaders"; "internetMessageId"; "isDeliveryReceiptRequested"; \
+			"isDraft"; "isRead"; "isReadReceiptRequested"; "lastModifiedDateTime"; \
+			"multiValueExtendedProperties"; "parentFolderId"; "receivedDateTime"; \
+			"replyTo"; "sender"; "sentDateTime"; "singleValueExtendedProperties"; \
+			"subject"; "toRecipients"; "uniqueBody"; "webLink")
+		
 		var $messageKey : Text
 		For each ($messageKey; OB Keys($message))
-			var $isAllowed : Boolean:=False
-			Case of 
-				: ($messageKey="attachments")
-				: ($messageKey="bccRecipients")
-				: ($messageKey="body")
-				: ($messageKey="bodyPreview")
-				: ($messageKey="categories")
-				: ($messageKey="ccRecipients")
-				: ($messageKey="changeKey")
-				: ($messageKey="conversationId")
-				: ($messageKey="conversationIndex")
-				: ($messageKey="createdDateTime")
-				: ($messageKey="extensions")
-				: ($messageKey="flag")
-				: ($messageKey="from")
-				: ($messageKey="hasAttachments")
-				: ($messageKey="id")
-				: ($messageKey="importance")
-				: ($messageKey="inferenceClassification")
-				: ($messageKey="internetMessageHeaders")
-				: ($messageKey="internetMessageId")
-				: ($messageKey="isDeliveryReceiptRequested")
-				: ($messageKey="isDraft")
-				: ($messageKey="isRead")
-				: ($messageKey="isReadReceiptRequested")
-				: ($messageKey="lastModifiedDateTime")
-				: ($messageKey="multiValueExtendedProperties")
-				: ($messageKey="parentFolderId")
-				: ($messageKey="receivedDateTime")
-				: ($messageKey="replyTo")
-				: ($messageKey="sender")
-				: ($messageKey="sentDateTime")
-				: ($messageKey="singleValueExtendedProperties")
-				: ($messageKey="subject")
-				: ($messageKey="toRecipients")
-				: ($messageKey="uniqueBody")
-				: ($messageKey="webLink")
-					$isAllowed:=True
-			End case 
-			
-			If (Not($isAllowed))
+			If ($allowedMessageKeys.indexOf($messageKey)<0)
 				This._pushError(12; {function: $inFunction; message: "Unsupported property \""+$messageKey+"\" in mail object."})
+				$isValid:=False
+			End if 
+		End for each 
+		
+	End if 
+	
+	return $isValid
+	
+	
+	// ----------------------------------------------------
+	
+	
+Function _validateJMAPMessageProperties($inMail : Object; $inFunction : Text) : Boolean
+/**
+ * @function _validateJMAPMessageProperties
+ * @private
+ * @param {Object} $inMail - 4D JMAP email object (as produced by `MAIL Convert from MIME`)
+ * @param {Text} $inFunction - Caller function name for error reporting
+ * @returns {Boolean} `True` when all properties are valid RFC 8621 / 4D JMAP properties;
+ *   otherwise `False`
+ * @description Validates a JMAP mail object against the set of properties supported by
+ *   4D's `MAIL Convert to MIME` command (RFC 8621). Adds an error to the stack for each
+ *   unsupported property.
+ */
+	
+	var $isValid : Boolean:=True
+	
+	If (($inMail#Null) && (Value type($inMail)=Is object))
+		
+		var $allowedKeys : Collection:=New collection(\
+			"from"; "to"; "cc"; "bcc"; "replyTo"; "sender"; \
+			"subject"; "sentAt"; "receivedAt"; \
+			"textBody"; "htmlBody"; "bodyValues"; \
+			"attachments"; "keywords"; "headers"; \
+			"messageId"; "inReplyTo"; "references"; \
+			"id"; "threadId"; "preview"; "size"; "hasAttachment"; "mailboxIds")
+		
+		var $key : Text
+		For each ($key; OB Keys($inMail))
+			If ($allowedKeys.indexOf($key)<0)
+				This._pushError(12; {function: $inFunction; message: "Unsupported property \""+$key+"\" in JMAP mail object."})
 				$isValid:=False
 			End if 
 		End for each 


### PR DESCRIPTION
Commit message:
Refs #85
Fix Office365 Graph mail property validation (unknown keys + valid Graph fields)

PR description:
Fixes #85

Reject unknown Graph mail properties with explicit errors (send/update), remove hardcoded attachment hint, and allow valid Graph fields (changeKey, extensions) so valid messages are not blocked.